### PR TITLE
default to '0' category if it's empty (this happens if you are making…

### DIFF
--- a/frontend/src/components/AccountTable/AccountTable.js
+++ b/frontend/src/components/AccountTable/AccountTable.js
@@ -826,7 +826,7 @@ export default function Account(props) {
           date: newRow.date,
           memo: newRow.memo,
           payeeId: newRow.payeeId,
-          categoryId: newRow.categoryId === '0' ? null : newRow.categoryId,
+          categoryId: newRow.categoryId === '0' || newRow.categoryId === '' ? null : newRow.categoryId,
           status: 0,
         },
       }),


### PR DESCRIPTION
… a trx on off-budget account but it's not a transfer)